### PR TITLE
Supporting new features of Ansible 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ These are the main variables:
 - `acme_directory`: The ACME directory to use. Default is `https://acme-v01.api.letsencrypt.org/directory`, which is the current production ACME endpoint of Let's Encrypt.
 - `challenge`: The challenge type to use. Should be `http-01` for HTTP challenges (needs access to web server) or `dns-01` for DNS challenges (needs access to DNS provider).
 - `root_certificate`: The root certificate for the ACME directory. Default value is `https://letsencrypt.org/certs/isrgrootx1.pem` for the root certificate of Let's Encrypt.
-- `intermediate_certificate`: The intermediate certificate for the ACME directory. Default value is `https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem` for the currently used intermediate certificate of Let's Encrypt.
 
 ### HTTP Challenges
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ These are the main variables:
 - `keys_path`: Where the keys and certificates are stored. Default value is `"keys/"`.
 - `ocsp_must_staple`: Whether a certificate with the OCSP Must Staple extension is requested. Default value is `False`.
 - `agreement`: The terms of service document the user agrees to. Default value is `https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf`.
-- `acme_directory`: The ACME directory to use. Default is `https://acme-v01.api.letsencrypt.org/directory`, which is the current production ACME endpoint of Let's Encrypt.
+- `acme_directory`: The ACME directory to use. Default is `https://acme-v02.api.letsencrypt.org/directory`, which is the current production ACME v2 endpoint of Let's Encrypt.
+- `acme_version`: The ACME directory's version. Default is 2. Use 1 for ACME v1.
 - `challenge`: The challenge type to use. Should be `http-01` for HTTP challenges (needs access to web server) or `dns-01` for DNS challenges (needs access to DNS provider).
 - `root_certificate`: The root certificate for the ACME directory. Default value is `https://letsencrypt.org/certs/isrgrootx1.pem` for the root certificate of Let's Encrypt.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,12 @@ key_length: 4096
 key_name: "{{ domains[0].replace('*', '_') }}"
 keys_path: "keys/"
 ocsp_must_staple: False
-agreement: https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf
+terms_agreed: true
 acme_directory: https://acme-v01.api.letsencrypt.org/directory
+acme_version: 1
 # For staging, use:
 #   acme_directory: https://acme-staging.api.letsencrypt.org/directory
+#   acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
 challenge: http-01
 root_certificate: https://letsencrypt.org/certs/isrgrootx1.pem
 intermediate_certificate: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ acme_version: 1
 #   acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
 challenge: http-01
 root_certificate: https://letsencrypt.org/certs/isrgrootx1.pem
+# For staging, use:
+#   root_certificate: https://letsencrypt.org/certs/fakelerootx1.pem
 
 # For HTTP challenges:
 server_location: /var/www/challenges

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ acme_version: 1
 #   acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
 challenge: http-01
 root_certificate: https://letsencrypt.org/certs/isrgrootx1.pem
-intermediate_certificate: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
 
 # For HTTP challenges:
 server_location: /var/www/challenges

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,11 +4,14 @@ key_name: "{{ domains[0].replace('*', '_') }}"
 keys_path: "keys/"
 ocsp_must_staple: False
 terms_agreed: true
-acme_directory: https://acme-v01.api.letsencrypt.org/directory
-acme_version: 1
+acme_directory: https://acme-v02.api.letsencrypt.org/directory
+acme_version: 2
+# For ACME v1:
+#   acme_directory: https://acme-v01.api.letsencrypt.org/directory
+#   acme_version: 1
 # For staging, use:
-#   acme_directory: https://acme-staging.api.letsencrypt.org/directory
-#   acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+#   acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory  (ACME v2)
+#   acme_directory: https://acme-staging.api.letsencrypt.org/directory  (ACME v1)
 challenge: http-01
 root_certificate: https://letsencrypt.org/certs/isrgrootx1.pem
 # For staging, use:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.2
+  min_ansible_version: 2.5
 
   galaxy_tags:
   - letsencrypt

--- a/tasks/dns-gcdns-cleanup.yml
+++ b/tasks/dns-gcdns-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 # Clean up DNS challenges for DNS provider Google Cloud DNS
-- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }}" via Google Cloud DNS
+- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }} via Google Cloud DNS
   local_action:
     module: gcdns_record
     state: absent

--- a/tasks/dns-gcdns-cleanup.yml
+++ b/tasks/dns-gcdns-cleanup.yml
@@ -4,15 +4,15 @@
   local_action:
     module: gcdns_record
     state: absent
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 300
-    value: '"{{ item.value[challenge].resource_value }}"'
+    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
     overwrite: true
     ...
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.get('challenge_data', {}) }}"
+  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-gcdns-cleanup.yml
+++ b/tasks/dns-gcdns-cleanup.yml
@@ -4,15 +4,15 @@
   local_action:
     module: gcdns_record
     state: absent
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 300
-    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
+    record_data: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
     overwrite: true
     ...
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.get('challenge_data_dns', {}) }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-gcdns-create.yml
+++ b/tasks/dns-gcdns-create.yml
@@ -4,15 +4,15 @@
   local_action:
     module: gcdns_record
     state: present
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 300
-    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
+    record_data: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
     overwrite: true
     ...
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.challenge_data_dns }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-gcdns-create.yml
+++ b/tasks/dns-gcdns-create.yml
@@ -1,6 +1,6 @@
 ---
 # Create DNS challenges for DNS provider Google Cloud DNS
-- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }}" via Google Cloud DNS
+- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }} via Google Cloud DNS
   local_action:
     module: gcdns_record
     state: present

--- a/tasks/dns-gcdns-create.yml
+++ b/tasks/dns-gcdns-create.yml
@@ -4,15 +4,15 @@
   local_action:
     module: gcdns_record
     state: present
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 300
-    value: '"{{ item.value[challenge].resource_value }}"'
+    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
     overwrite: true
     ...
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.challenge_data }}"
+  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-hosttech-cleanup.yml
+++ b/tasks/dns-hosttech-cleanup.yml
@@ -4,16 +4,16 @@
   local_action:
     module: hosttech_dns
     state: absent
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 300
-    value: "{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"
+    value: "{{ item.value }}"
     overwrite: true
     hosttech_username: "{{ hosttech_username }}"
     hosttech_password: "{{ hosttech_password }}"
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.get('challenge_data_dns', {}) }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-hosttech-cleanup.yml
+++ b/tasks/dns-hosttech-cleanup.yml
@@ -4,16 +4,16 @@
   local_action:
     module: hosttech_dns
     state: absent
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 300
-    value: "{{ item.value[challenge].resource_value }}"
+    value: "{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"
     overwrite: true
     hosttech_username: "{{ hosttech_username }}"
     hosttech_password: "{{ hosttech_password }}"
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.get('challenge_data', {}) }}"
+  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-hosttech-cleanup.yml
+++ b/tasks/dns-hosttech-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 # Clean up DNS challenges for DNS provider HostTech
-- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }}" via HostTech API
+- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }} via HostTech API
   local_action:
     module: hosttech_dns
     state: absent

--- a/tasks/dns-hosttech-create.yml
+++ b/tasks/dns-hosttech-create.yml
@@ -4,16 +4,16 @@
   local_action:
     module: hosttech_dns
     state: present
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 300
-    value: "{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"
+    value: "{{ item.value }}"
     overwrite: true
     hosttech_username: "{{ hosttech_username }}"
     hosttech_password: "{{ hosttech_password }}"
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.challenge_data_dns }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-hosttech-create.yml
+++ b/tasks/dns-hosttech-create.yml
@@ -1,6 +1,6 @@
 ---
 # Create DNS challenges for DNS provider HostTech
-- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }}" via HostTech API
+- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }} via HostTech API
   local_action:
     module: hosttech_dns
     state: present

--- a/tasks/dns-hosttech-create.yml
+++ b/tasks/dns-hosttech-create.yml
@@ -4,16 +4,16 @@
   local_action:
     module: hosttech_dns
     state: present
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 300
-    value: "{{ item.value[challenge].resource_value }}"
+    value: "{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"
     overwrite: true
     hosttech_username: "{{ hosttech_username }}"
     hosttech_password: "{{ hosttech_password }}"
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.challenge_data }}"
+  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-route53-cleanup.yml
+++ b/tasks/dns-route53-cleanup.yml
@@ -4,16 +4,16 @@
   local_action:
     module: route53
     state: absent
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 60
-    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.get('challenge_data_dns', {}) }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-route53-cleanup.yml
+++ b/tasks/dns-route53-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 # Clean up DNS challenges for DNS provider Amazon Route53
-- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }}" via Route53
+- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }} via Route53
   local_action:
     module: route53
     state: absent

--- a/tasks/dns-route53-cleanup.yml
+++ b/tasks/dns-route53-cleanup.yml
@@ -4,16 +4,16 @@
   local_action:
     module: route53
     state: absent
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 60
-    value: '"{{ item.value[challenge].resource_value }}"'
+    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.get('challenge_data', {}) }}"
+  with_items: "{{ lets_encrypt_challenge.get('challenge_data', {}).values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-route53-cleanup.yml
+++ b/tasks/dns-route53-cleanup.yml
@@ -8,7 +8,7 @@
     record: "{{ item.key }}"
     type: TXT
     ttl: 60
-    value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"

--- a/tasks/dns-route53-create.yml
+++ b/tasks/dns-route53-create.yml
@@ -4,17 +4,17 @@
   local_action:
     module: route53
     state: present
-    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item.value[challenge].resource }}.{{ item.key | regex_replace('^\\*\\.', '') }}"
+    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item }}"
     type: TXT
     ttl: 60
-    value: '"{{ item.value[challenge].resource_value }}"'
+    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     wait: true
   run_once: True
-  with_dict: "{{ lets_encrypt_challenge.challenge_data }}"
+  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-route53-create.yml
+++ b/tasks/dns-route53-create.yml
@@ -1,20 +1,20 @@
 ---
 # Create DNS challenges for DNS provider Amazon Route53
-- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }}" via Route53
+- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }} via Route53
   local_action:
     module: route53
     state: present
-    zone: "{{ item | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
-    record: "{{ item }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    record: "{{ item.key }}"
     type: TXT
     ttl: 60
-    value: '"{{ lets_encrypt_challenge.challenge_data.items() | selectattr('1.dns-01.record', 'equalto', item) | map(attribute='1.dns-01.resource_value') | list }}"'
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     wait: true
   run_once: True
-  with_items: "{{ lets_encrypt_challenge.challenge_data.values() | map(attribute='dns-01.record') | unique }}"
+  with_dict: "{{ lets_encrypt_challenge.challenge_data_dns }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/dns-route53-create.yml
+++ b/tasks/dns-route53-create.yml
@@ -8,7 +8,7 @@
     record: "{{ item.key }}"
     type: TXT
     ttl: 60
-    value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
+    value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
     overwrite: true
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"

--- a/tasks/http-create.yml
+++ b/tasks/http-create.yml
@@ -13,7 +13,7 @@
   - issue-tls-certs
 
 # Create challenge files on server.
-- name: Copying challenge files for domains {{ ', '.join(domains) }}"
+- name: "Copying challenge files for domains {{ ', '.join(domains) }}"
   copy:
     dest: "{{ server_location }}/{{ item.value[challenge].resource[('.well-known/acme-challenge/'|length):] }}"
     content: "{{ item.value[challenge].resource_value }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,52 +22,38 @@
   - create-tls-keys
   - create-tls-csr
 
-- block:
-  - name: "Get root certificate for domains {{ ', '.join(domains) }}"
-    local_action:
-      module: get_url
-      url: "{{ root_certificate }}"
-      dest: "{{ keys_path }}{{ key_name }}-root.pem"
-    run_once: True
-
-  - name: "Get intermediate certificate for domains {{ ', '.join(domains) }}"
-    local_action:
-      module: get_url
-      url: "{{ intermediate_certificate }}"
-      dest: "{{ keys_path }}{{ key_name }}-chain.pem"
-    run_once: True
-
-  - name: "Form root chain for domains {{ ', '.join(domains) }}"
-    local_action:
-      module: copy
-      dest: "{{ keys_path }}{{ key_name }}-rootchain.pem"
-      content: "{{ lookup('file', keys_path ~ key_name ~ '-root.pem') }}\n{{ lookup('file', keys_path ~ key_name ~ '-chain.pem') }}\n"
-    run_once: True
-  tags:
-  - issue-tls-certs-newkey
-  - issue-tls-certs
-  - get-tls-chain
-
-- name: "Preparing challenges for domains {{ ', '.join(domains) }}"
+- name: "Get root certificate for domains {{ ', '.join(domains) }}"
   local_action:
-    module: letsencrypt
-    account_key: "{{ acme_account }}"
-    csr: "{{ keys_path }}{{ key_name }}.csr"
-    dest: "{{ keys_path }}{{ key_name }}.pem"
-    fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
-    account_email: "{{ acme_email }}"
-    terms_agreed: "{{ terms_agreed }}"
-    challenge: "{{ challenge }}"
-    acme_directory: "{{ acme_directory }}"
-    acme_version: "{{ acme_version }}"
-    remaining_days: 91
+    module: get_url
+    url: "{{ root_certificate }}"
+    dest: "{{ keys_path }}{{ key_name }}-root.pem"
   run_once: True
-  register: lets_encrypt_challenge
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs
 
-- debug: msg="account URI: {{ lets_encrypt_challenge.account_uri }}; order URI: {{ lets_encrypt_challenge.order_uri }}"
+- block:
+  - name: "Preparing challenges for domains {{ ', '.join(domains) }}"
+    local_action:
+      module: letsencrypt
+      account_key: "{{ acme_account }}"
+      csr: "{{ keys_path }}{{ key_name }}.csr"
+      dest: "{{ keys_path }}{{ key_name }}.pem"
+      fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
+      chain_dest: "{{ keys_path }}{{ key_name }}-chain.pem"
+      account_email: "{{ acme_email }}"
+      terms_agreed: "{{ terms_agreed }}"
+      challenge: "{{ challenge }}"
+      acme_directory: "{{ acme_directory }}"
+      acme_version: "{{ acme_version }}"
+      remaining_days: 91
+    run_once: True
+    register: lets_encrypt_challenge
+
+  always:
+  - debug:
+      msg: "account URI: {{ lets_encrypt_challenge.get('account_uri') }}; order URI: {{ lets_encrypt_challenge.get('order_uri') }}"
+
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs
@@ -88,6 +74,7 @@
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
       fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
+      chain_dest: "{{ keys_path }}{{ key_name }}-chain.pem"
       account_email: "{{ acme_email }}"
       terms_agreed: "{{ terms_agreed }}"
       challenge: "{{ challenge }}"
@@ -97,6 +84,12 @@
       data: "{{ lets_encrypt_challenge }}"
     run_once: True
 
+  - name: "Form root chain for domains {{ ', '.join(domains) }}"
+    local_action:
+      module: copy
+      dest: "{{ keys_path }}{{ key_name }}-rootchain.pem"
+      content: "{{ lookup('file', keys_path ~ key_name ~ '-root.pem') }}\n{{ lookup('file', keys_path ~ key_name ~ '-chain.pem') }}\n"
+    run_once: True
   always:
   # Clean up HTTP challenges
   - include_tasks: http-cleanup.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,10 +54,12 @@
     account_key: "{{ acme_account }}"
     csr: "{{ keys_path }}{{ key_name }}.csr"
     dest: "{{ keys_path }}{{ key_name }}.pem"
+    fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
     account_email: "{{ acme_email }}"
-    agreement: "{{ agreement }}"
+    terms_agreed: "{{ terms_agreed }}"
     challenge: "{{ challenge }}"
     acme_directory: "{{ acme_directory }}"
+    acme_version: "{{ acme_version }}"
     remaining_days: 91
   run_once: True
   register: lets_encrypt_challenge
@@ -65,13 +67,18 @@
   - issue-tls-certs-newkey
   - issue-tls-certs
 
+- debug: msg="account URI: {{ lets_encrypt_challenge.account_uri }}; order URI: {{ lets_encrypt_challenge.order_uri }}"
+  tags:
+  - issue-tls-certs-newkey
+  - issue-tls-certs
+
 - block:
   # Set up HTTP challenges
-  - include: http-create.yml
+  - include_tasks: http-create.yml
     when: "challenge == 'http-01'"
 
   # Set up DNS challenges
-  - include: dns-{{ dns_provider }}-create.yml
+  - include_tasks: dns-{{ dns_provider }}-create.yml
     when: "challenge == 'dns-01'"
 
   - name: "Getting certificates for domains {{ ', '.join(domains) }}"
@@ -80,34 +87,29 @@
       account_key: "{{ acme_account }}"
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
+      fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
       account_email: "{{ acme_email }}"
-      agreement: "{{ agreement }}"
+      terms_agreed: "{{ terms_agreed }}"
       challenge: "{{ challenge }}"
       acme_directory: "{{ acme_directory }}"
+      acme_version: "{{ acme_version }}"
       remaining_days: 91
       data: "{{ lets_encrypt_challenge }}"
     run_once: True
 
-  - name: "Creating chained certificate for domains {{ ', '.join(domains) }}"
-    local_action:
-      module: copy
-      dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
-      content: "{{ lookup('file', keys_path ~ key_name ~ '.pem') }}\n{{ lookup('file', keys_path ~ key_name ~ '-chain.pem') }}\n"
-    run_once: True
-
   always:
   # Clean up HTTP challenges
-  - include: http-cleanup.yml
+  - include_tasks: http-cleanup.yml
     when: "challenge == 'http-01'"
 
   # Clean up DNS challenges
-  - include: dns-{{ dns_provider }}-cleanup.yml
+  - include_tasks: dns-{{ dns_provider }}-cleanup.yml
     when: "challenge == 'dns-01'"
 
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs
-  when: lets_encrypt_challenge|changed
+  when: lets_encrypt_challenge is changed
 
 - name: "Verifying certificate for domains {{ ', '.join(domains) }}"
   local_action:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,23 @@
 ---
+- name: Ansible version check
+  assert:
+    that: "(ansible_version.major, ansible_version.minor) >= (2, 5)"
+    msg: "This version of the letsencrypt role must be used with Ansible 2.5 or later."
+  tags:
+  - issue-tls-certs-newkey
+  - issue-tls-certs
+  - create-tls-keys
+  - create-tls-csr
+
 - name: Sanity checks
-  fail:
+  assert:
+    that: "challenge != 'dns-01' or dns_provider is not undefined"
     msg: "dns_provider must be defined for dns-01 DNS challenge"
-  when: "challenge == 'dns-01' and dns_provider is undefined"
+  tags:
+  - issue-tls-certs-newkey
+  - issue-tls-certs
+  - create-tls-keys
+  - create-tls-csr
 
 - block:
   - name: "Creating private key for domains {{ ', '.join(domains) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ansible version check
   assert:
-    that: "(ansible_version.major, ansible_version.minor) >= (2, 5)"
-    msg: "This version of the letsencrypt role must be used with Ansible 2.5 or later."
+    that: "ansible_version | version_compare(2.5.1, '>=')"
+    msg: "This version of the letsencrypt role must be used with Ansible 2.5.1 or later."
   run_once: True
   tags:
   - issue-tls-certs-newkey

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   assert:
     that: "(ansible_version.major, ansible_version.minor) >= (2, 5)"
     msg: "This version of the letsencrypt role must be used with Ansible 2.5 or later."
+  run_once: True
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs
@@ -13,6 +14,7 @@
   assert:
     that: "challenge != 'dns-01' or dns_provider is not undefined"
     msg: "dns_provider must be defined for dns-01 DNS challenge"
+  run_once: True
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs
@@ -68,6 +70,7 @@
   always:
   - debug:
       msg: "account URI: {{ lets_encrypt_challenge.get('account_uri') }}; order URI: {{ lets_encrypt_challenge.get('order_uri') }}"
+    run_once: True
 
   tags:
   - issue-tls-certs-newkey


### PR DESCRIPTION
[Ansible 2.5](https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_5.html) should be released in March 2018. It will support the ACME v2 protocol, this allow wildcard certificates. It also supports fetching the correct intermediate certificate, and there's no more need to specify the TOS agreement URL.